### PR TITLE
Bugfix for case when time interval is >= one day

### DIFF
--- a/tint/helpers.py
+++ b/tint/helpers.py
@@ -144,7 +144,7 @@ class Record(object):
         old_diff = self.interval
         self.interval = time2 - self.time
         if old_diff is not None:
-            self.interval_ratio = self.interval.seconds/old_diff.seconds
+            self.interval_ratio = self.interval.total_seconds()/old_diff.total_seconds()
 
 
 def spl(present, time):

--- a/tint/visualization.py
+++ b/tint/visualization.py
@@ -16,7 +16,7 @@ import tempfile
 import matplotlib as mpl
 from subprocess import run, CalledProcessError, PIPE
 import shlex
-from mpl_toolkits.basemap import Basemap
+from cartopy import crs as ccrs
 from IPython.display import display, Image
 from matplotlib import pyplot as plt
 from datetime import timedelta
@@ -86,7 +86,7 @@ def full_domain(tobj, grids, tmp_dir, vmin=0.01, vmax=15, cmap=None, alt=None,
     nframes = tobj.tracks.index.levels[0].max() + 1
     print('Animating', nframes, 'frames')
     fig = plt.figure(figsize=(10, 8))
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(111,projection=ccrs.PlateCarree())
 
     for nframe, grid in enumerate(grids):
         sys.stdout.flush()
@@ -96,9 +96,9 @@ def full_domain(tobj, grids, tmp_dir, vmin=0.01, vmax=15, cmap=None, alt=None,
         if nframe == 0:
             X = grid['lon']
             Y = grid['lat']
-            m = Basemap(llcrnrlat=Y.min(), llcrnrlon=X.min(), urcrnrlat=Y.max(),
-                        urcrnrlon=X.max(), resolution=basemap_res, ax=ax)
-            m.drawcoastlines()
+#            m = Basemap(llcrnrlat=Y.min(), llcrnrlon=X.min(), urcrnrlat=Y.max(),
+#                        urcrnrlon=X.max(), resolution=basemap_res, ax=ax)
+            ax.coastlines()
             try:
                 im = m.pcolormesh(X, Y, grid['data'][0].filled(np.nan),
                         vmin=vmin, vmax=vmax, cmap=cmap, shading='gouraud')
@@ -256,7 +256,7 @@ def plot_traj(traj, X, Y, mpp=None, label=False, basemap_res='i',
     thresh : tuple for thresholds to be applied to the plotted objects. first
         entry of the tuple is the variable (default 'mean') second one the
         the minimum value (default -1)
-    create_map: boolean, reate a map object, this can be useful for loops where
+    create_map: boolean, create a map object, this can be useful for loops where
         a basemap object has already been created
     pos_columns : list of strings, optional
         Dataframe column names for spatial coordinates. Default is ['x', 'y'].
@@ -274,15 +274,16 @@ def plot_traj(traj, X, Y, mpp=None, label=False, basemap_res='i',
     from matplotlib.collections import LineCollection
     if ax is None:
         fig = plt.figure(figsize=(10, 8))
-        ax = fig.add_subplot(111)
+        ax = fig.add_subplot(111,projection=ccrs.PlateCarree())
     if create_map is None :
-        m = Basemap(llcrnrlat=Y.min(), llcrnrlon=X.min(), urcrnrlat=Y.max(),
-                urcrnrlon=X.max(), resolution=basemap_res, ax=ax)
+#        m = Basemap(llcrnrlat=Y.min(), llcrnrlon=X.min(), urcrnrlat=Y.max(),
+#                urcrnrlon=X.max(), resolution=basemap_res, ax=ax)
         try:
             lw=plot_style['lw']
         except KeyError:
             lw=0.5
-        m.drawcoastlines(linewidth=lw)
+#        m.drawcoastlines(linewidth=lw)
+        ax.coastlines(linewidth=lw)
     else:
         m = create_map
 

--- a/tint/visualization.py
+++ b/tint/visualization.py
@@ -16,7 +16,7 @@ import tempfile
 import matplotlib as mpl
 from subprocess import run, CalledProcessError, PIPE
 import shlex
-from cartopy import crs as ccrs
+from mpl_toolkits.basemap import Basemap
 from IPython.display import display, Image
 from matplotlib import pyplot as plt
 from datetime import timedelta
@@ -86,7 +86,7 @@ def full_domain(tobj, grids, tmp_dir, vmin=0.01, vmax=15, cmap=None, alt=None,
     nframes = tobj.tracks.index.levels[0].max() + 1
     print('Animating', nframes, 'frames')
     fig = plt.figure(figsize=(10, 8))
-    ax = fig.add_subplot(111,projection=ccrs.PlateCarree())
+    ax = fig.add_subplot(111)
 
     for nframe, grid in enumerate(grids):
         sys.stdout.flush()
@@ -96,9 +96,9 @@ def full_domain(tobj, grids, tmp_dir, vmin=0.01, vmax=15, cmap=None, alt=None,
         if nframe == 0:
             X = grid['lon']
             Y = grid['lat']
-#            m = Basemap(llcrnrlat=Y.min(), llcrnrlon=X.min(), urcrnrlat=Y.max(),
-#                        urcrnrlon=X.max(), resolution=basemap_res, ax=ax)
-            ax.coastlines()
+            m = Basemap(llcrnrlat=Y.min(), llcrnrlon=X.min(), urcrnrlat=Y.max(),
+                        urcrnrlon=X.max(), resolution=basemap_res, ax=ax)
+            m.drawcoastlines()
             try:
                 im = m.pcolormesh(X, Y, grid['data'][0].filled(np.nan),
                         vmin=vmin, vmax=vmax, cmap=cmap, shading='gouraud')
@@ -256,7 +256,7 @@ def plot_traj(traj, X, Y, mpp=None, label=False, basemap_res='i',
     thresh : tuple for thresholds to be applied to the plotted objects. first
         entry of the tuple is the variable (default 'mean') second one the
         the minimum value (default -1)
-    create_map: boolean, create a map object, this can be useful for loops where
+    create_map: boolean, reate a map object, this can be useful for loops where
         a basemap object has already been created
     pos_columns : list of strings, optional
         Dataframe column names for spatial coordinates. Default is ['x', 'y'].
@@ -274,16 +274,15 @@ def plot_traj(traj, X, Y, mpp=None, label=False, basemap_res='i',
     from matplotlib.collections import LineCollection
     if ax is None:
         fig = plt.figure(figsize=(10, 8))
-        ax = fig.add_subplot(111,projection=ccrs.PlateCarree())
+        ax = fig.add_subplot(111)
     if create_map is None :
-#        m = Basemap(llcrnrlat=Y.min(), llcrnrlon=X.min(), urcrnrlat=Y.max(),
-#                urcrnrlon=X.max(), resolution=basemap_res, ax=ax)
+        m = Basemap(llcrnrlat=Y.min(), llcrnrlon=X.min(), urcrnrlat=Y.max(),
+                urcrnrlon=X.max(), resolution=basemap_res, ax=ax)
         try:
             lw=plot_style['lw']
         except KeyError:
             lw=0.5
-#        m.drawcoastlines(linewidth=lw)
-        ax.coastlines(linewidth=lw)
+        m.drawcoastlines(linewidth=lw)
     else:
         m = create_map
 


### PR DESCRIPTION
The `datetime.timedelta` object stores time intervals in days and seconds, meaning that if the analyzed data is daily, `.interval.seconds = 0` in `update_scan_and_time()`. This pull request changes this to using `.interval.total_seconds()`, which will be 86400 for daily data, and can also deal with larger time intervals.